### PR TITLE
Handle ForeignKey fields returned as nested dicts by get_object

### DIFF
--- a/examples/demo_magnet_parts.py
+++ b/examples/demo_magnet_parts.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+demo_magnet_parts.py — Parts of a magnet
+=========================================
+For a given magnet name, retrieve all associated parts and display their
+name, type, status, and material in a table.
+
+Requires GET /api/magnets/{id}/parts to be available in magnetdb.
+
+Usage
+-----
+    export MAGNETDB_API_SERVER=api.magnetdb-dev.local   # host only, no scheme
+    export MAGNETDB_API_KEY=<your-key>
+    python demo_magnet_parts.py --magnet M18110501
+
+Optional flags
+--------------
+    --server  override MAGNETDB_API_SERVER
+    --https   use HTTPS instead of HTTP (default: HTTP on port 8000)
+    --debug   print raw API responses
+"""
+
+import os
+import sys
+import argparse
+
+import requests
+from rich.console import Console
+from rich.table import Table
+
+from python_magnetapi import utils
+
+
+def get_magnet_id(session, web: str, headers: dict, magnet_name: str, debug: bool) -> int:
+    """Resolve a magnet name to its numeric id."""
+    ids = utils.get_list(session, web, headers=headers, mtype="magnet", debug=debug)
+    if magnet_name not in ids:
+        available = sorted(ids.keys())
+        print(
+            f"ERROR: magnet '{magnet_name}' not found.\n"
+            f"Available magnets ({len(available)}): {available}"
+        )
+        sys.exit(1)
+    return ids[magnet_name]
+
+
+def main():
+    api_server = os.getenv("MAGNETDB_API_SERVER") or "api.magnetdb-dev.local"
+
+    parser = argparse.ArgumentParser(description="Show parts of a magnet")
+    parser.add_argument("--magnet", required=True, help="Magnet name to inspect")
+    parser.add_argument("--server", default=api_server, help="API server hostname")
+    parser.add_argument("--port",   type=int, default=8000, help="Port (HTTP only)")
+    parser.add_argument("--https",  action="store_true", help="Use HTTPS")
+    parser.add_argument("--debug",  action="store_true", help="Verbose API output")
+    args = parser.parse_args()
+
+    web = (
+        f"https://{args.server}"
+        if args.https
+        else f"http://{args.server}:{args.port}"
+    )
+    headers = {"Authorization": os.getenv("MAGNETDB_API_KEY", "")}
+
+    console = Console()
+
+    with requests.Session() as session:
+        # health-check
+        r = session.get(f"{web}/api/magnets", headers=headers)
+        if r.status_code != 200:
+            console.print(f"[red]ERROR:[/red] cannot reach {web} (status {r.status_code})")
+            sys.exit(1)
+
+        # resolve magnet name → id
+        magnet_id = get_magnet_id(session, web, headers, args.magnet, args.debug)
+        magnet = utils.get_object(
+            session, web, headers=headers, mtype="magnet", id=magnet_id, debug=args.debug
+        )
+
+        console.print(f"\n[bold]Magnet:[/bold] {magnet.get('name')}  (id={magnet_id})")
+        console.print()
+
+        # fetch parts via GET /api/magnets/{id}/parts
+        parts = utils.get_parts_for_magnet(
+            session, web, headers, magnet_id, debug=args.debug
+        )
+
+        if not parts:
+            console.print("[yellow]No parts found for this magnet.[/yellow]")
+            return
+
+        # build table
+        table = Table(title=f"Parts of magnet '{args.magnet}'")
+        table.add_column("Part name",    style="cyan",  no_wrap=True)
+        table.add_column("Type",         style="white")
+        table.add_column("Status",       style="white")
+        table.add_column("Material",     style="green")
+
+        for part in parts:
+            # material_id is a direct FK column returned by model_serializer
+            material_id = utils.get_fk_id(part, "material")
+            if material_id is not None:
+                mat = utils.get_object(
+                    session, web, headers=headers, mtype="material",
+                    id=material_id, debug=args.debug,
+                )
+                material_name = mat.get("name", str(material_id)) if mat else str(material_id)
+            else:
+                material_name = "—"
+
+            table.add_row(
+                part.get("name", "?"),
+                part.get("type", "?"),
+                part.get("status", "?"),
+                material_name,
+            )
+
+        console.print(table)
+        console.print()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/demo_magnet_parts.py
+++ b/examples/demo_magnet_parts.py
@@ -15,9 +15,10 @@ Usage
 
 Optional flags
 --------------
-    --server  override MAGNETDB_API_SERVER
-    --https   use HTTPS instead of HTTP (default: HTTP on port 8000)
-    --debug   print raw API responses
+    --server     override MAGNETDB_API_SERVER
+    --https      use HTTPS instead of HTTP (default: HTTP on port 8000)
+    --no-verify  skip TLS certificate verification (self-signed certs)
+    --debug      print raw API responses
 """
 
 import os
@@ -25,6 +26,7 @@ import sys
 import argparse
 
 import requests
+import urllib3
 from rich.console import Console
 from rich.table import Table
 
@@ -51,7 +53,9 @@ def main():
     parser.add_argument("--magnet", required=True, help="Magnet name to inspect")
     parser.add_argument("--server", default=api_server, help="API server hostname")
     parser.add_argument("--port",   type=int, default=8000, help="Port (HTTP only)")
-    parser.add_argument("--https",  action="store_true", help="Use HTTPS")
+    parser.add_argument("--https",     action="store_true", help="Use HTTPS")
+    parser.add_argument("--no-verify", action="store_true",
+                        help="Skip TLS certificate verification (self-signed certs)")
     parser.add_argument("--debug",  action="store_true", help="Verbose API output")
     args = parser.parse_args()
 
@@ -62,9 +66,13 @@ def main():
     )
     headers = {"Authorization": os.getenv("MAGNETDB_API_KEY", "")}
 
+    if args.no_verify:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
     console = Console()
 
     with requests.Session() as session:
+        session.verify = not args.no_verify
         # health-check
         r = session.get(f"{web}/api/magnets", headers=headers)
         if r.status_code != 200:

--- a/examples/demo_part_history.py
+++ b/examples/demo_part_history.py
@@ -155,7 +155,9 @@ def main():
     parser.add_argument("--part",   required=True, help="Part name to inspect")
     parser.add_argument("--server", default=api_server, help="API server hostname")
     parser.add_argument("--port",   type=int, default=8000, help="Port (HTTP only)")
-    parser.add_argument("--https",  action="store_true", help="Use HTTPS")
+    parser.add_argument("--https",     action="store_true", help="Use HTTPS")
+    parser.add_argument("--no-verify", action="store_true",
+                        help="Skip TLS certificate verification (self-signed certs)")
     parser.add_argument("--debug",  action="store_true", help="Verbose API output")
     args = parser.parse_args()
 
@@ -166,7 +168,12 @@ def main():
     )
     headers = {"Authorization": os.getenv("MAGNETDB_API_KEY", "")}
 
+    if args.no_verify:
+        import urllib3
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
     with requests.Session() as session:
+        session.verify = not args.no_verify
         # --- health-check ---------------------------------------------------
         r = session.get(f"{web}/api/magnets", headers=headers)
         if r.status_code != 200:

--- a/examples/demo_part_site_records.py
+++ b/examples/demo_part_site_records.py
@@ -174,7 +174,9 @@ def main():
     parser.add_argument("--part",   required=True, help="Part name to inspect")
     parser.add_argument("--server", default=api_server)
     parser.add_argument("--port",   type=int, default=8000)
-    parser.add_argument("--https",  action="store_true")
+    parser.add_argument("--https",     action="store_true")
+    parser.add_argument("--no-verify", action="store_true",
+                        help="Skip TLS certificate verification (self-signed certs)")
     parser.add_argument("--json",   action="store_true", help="Dump raw site JSON at end")
     parser.add_argument("--debug",  action="store_true")
     args = parser.parse_args()
@@ -186,7 +188,12 @@ def main():
     )
     headers = {"Authorization": os.getenv("MAGNETDB_API_KEY", "")}
 
+    if args.no_verify:
+        import urllib3
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
     with requests.Session() as session:
+        session.verify = not args.no_verify
         # health-check
         r = session.get(f"{web}/api/magnets", headers=headers)
         if r.status_code != 200:

--- a/python_magnetapi/cli/context.py
+++ b/python_magnetapi/cli/context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import urllib3
 from dataclasses import dataclass, field
 from typing import Optional
 import requests
@@ -17,6 +18,7 @@ class CLIContext:
         api_key: API authentication key
         debug: Debug mode flag
         https: Use HTTPS flag
+        no_verify: Skip TLS certificate verification (self-signed certs)
         session: Requests session (initialized later)
     """
 
@@ -25,6 +27,7 @@ class CLIContext:
     api_key: str
     debug: bool = False
     https: bool = False
+    no_verify: bool = False
     session: Optional[requests.Session] = field(default=None, repr=False)
 
     @property
@@ -39,15 +42,12 @@ class CLIContext:
             return f"https://{self.server}"
         return f"http://{self.server}:{self.port}"
 
-    @property
-    def verify_ssl(self) -> bool:
-        """Whether to verify SSL certificates."""
-        return not self.https
-
     def __enter__(self) -> CLIContext:
         """Context manager entry - create session."""
+        if self.no_verify:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.session = requests.Session()
-        self.session.verify = self.verify_ssl
+        self.session.verify = not self.no_verify
         return self
 
     def __exit__(

--- a/python_magnetapi/part.py
+++ b/python_magnetapi/part.py
@@ -47,16 +47,20 @@ def create(
                 required_by=data["name"],
             )
     elif isinstance(mat, dict):
-        mname = mat["name"]
-        _id = -1
-        if mname in mat_ids:
-            _id = mat_ids[mname]
+        # If the dict already has an "id" key it is an API response object —
+        # use the id directly without an extra lookup.
+        if "id" in mat:
+            data["material_id"] = mat["id"]
         else:
-            _id = material.create(
-                session, api_server, headers, mat, verbose=verbose, debug=debug
-            )
-
-        data["material_id"] = _id
+            mname = mat["name"]
+            _id = -1
+            if mname in mat_ids:
+                _id = mat_ids[mname]
+            else:
+                _id = material.create(
+                    session, api_server, headers, mat, verbose=verbose, debug=debug
+                )
+            data["material_id"] = _id
         del data["material"]
     else:
         raise ValidationError(

--- a/python_magnetapi/utils.py
+++ b/python_magnetapi/utils.py
@@ -145,22 +145,85 @@ def get_object(
 
 def get_fk_id(obj: dict, field: str) -> int | None:
     """
-    Extract the integer ID from a ForeignKey field in an object returned by get_object.
+    Extract the integer ID for a direct/forward ForeignKey field from a
+    MagnetDB API response dict (as returned by get_object).
 
-    MagnetDB API returns ForeignKey fields as nested dicts, e.g.:
-        {"material": {"id": 5, "name": "copper", ...}}
+    Django serializes a ForeignKey named `material` as the column `material_id`
+    (an integer), not as a nested object.  Checks in order:
+      1. "{field}_id" key  — standard Django column name (primary form)
+      2. "{field}" key holding an int
+      3. "{field}" key holding a dict with "id" (defensive fallback)
 
-    This helper handles all three forms a FK field can appear in:
-    - dict with "id" key (API response): return dict["id"]
-    - int: return as-is (already an ID)
-    - None / missing: return None
+    For reverse FK / many-to-many relations (e.g. parts on a magnet) the
+    related objects are NOT in the get_object response.
+    Use get_parts_for_magnet() or an equivalent nested-endpoint helper instead.
     """
+    fk_col = f"{field}_id"
+    if fk_col in obj:
+        return obj[fk_col]
     value = obj.get(field)
-    if isinstance(value, dict):
-        return value.get("id")
     if isinstance(value, int):
         return value
+    if isinstance(value, dict):
+        return value.get("id")
     return None
+
+
+def get_parts_for_magnet(
+    session,
+    api_server: str,
+    headers: dict,
+    magnet_id: int,
+    verbose: bool = False,
+    debug: bool = False,
+) -> list:
+    """
+    Return the full Part objects associated with a magnet.
+
+    Calls GET /api/magnets/{magnet_id}/parts (must exist in magnetdb).
+    The endpoint may return either:
+    - a bare array of Part objects directly, or
+    - a bare array of MagnetPart join rows each containing a `part_id` field.
+
+    In the join-row case each part is fetched individually via get_object.
+    Returns a list of Part dicts (same structure as get_object(mtype="part")).
+    """
+    if verbose:
+        print(f"get_parts_for_magnet: api_server={api_server}, magnet_id={magnet_id}")
+
+    r = session.get(f"{api_server}/api/magnets/{magnet_id}/parts", headers=headers)
+    if r.status_code != 200:
+        print(
+            f"get_parts_for_magnet: {r.status_code} for magnet {magnet_id}"
+        )
+        return []
+
+    rows = r.json()
+    if debug:
+        print(f"get_parts_for_magnet: rows={rows}")
+
+    if not rows:
+        return []
+
+    # If the first row looks like a Part (has "name"), return as-is.
+    if "name" in rows[0]:
+        return rows
+
+    # Otherwise treat as MagnetPart join rows and fetch each Part individually.
+    parts = []
+    seen = set()
+    for row in rows:
+        part_id = row.get("part_id")
+        if part_id is None or part_id in seen:
+            continue
+        seen.add(part_id)
+        part = get_object(
+            session, api_server, headers, part_id, mtype="part",
+            verbose=verbose, debug=debug,
+        )
+        if part:
+            parts.append(part)
+    return parts
 
 
 def create_object(

--- a/python_magnetapi/utils.py
+++ b/python_magnetapi/utils.py
@@ -193,9 +193,7 @@ def get_parts_for_magnet(
 
     r = session.get(f"{api_server}/api/magnets/{magnet_id}/parts", headers=headers)
     if r.status_code != 200:
-        print(
-            f"get_parts_for_magnet: {r.status_code} for magnet {magnet_id}"
-        )
+        print(f"get_parts_for_magnet: {r.status_code} for magnet {magnet_id}")
         return []
 
     rows = r.json()
@@ -205,24 +203,42 @@ def get_parts_for_magnet(
     if not rows:
         return []
 
-    # If the first row looks like a Part (has "name"), return as-is.
-    if "name" in rows[0]:
-        return rows
+    print(
+        f"get_parts_for_magnet: {len(rows['parts'])} parts found for magnet {magnet_id}"
+    )
+    print(
+        f"get_parts_for_magnet: {[magnet_part.get('part').get('id') for magnet_part in rows['parts']]} parts found for magnet {magnet_id}"
+    )
 
-    # Otherwise treat as MagnetPart join rows and fetch each Part individually.
     parts = []
+
     seen = set()
-    for row in rows:
-        part_id = row.get("part_id")
+    for i, magnet_part in enumerate(rows["parts"]):
+        part_id = magnet_part.get("part").get("id")
         if part_id is None or part_id in seen:
             continue
-        seen.add(part_id)
-        part = get_object(
-            session, api_server, headers, part_id, mtype="part",
-            verbose=verbose, debug=debug,
-        )
-        if part:
-            parts.append(part)
+        try:
+            print(
+                f"get_parts_for_magnet: part[{i}] = id={part_id}", end=", ", flush=True
+            )
+            seen.add(part_id)
+            part = get_object(
+                session,
+                api_server,
+                headers,
+                part_id,
+                mtype="part",
+                verbose=verbose,
+                debug=debug,
+            )
+            print(
+                f"name={part.get('name')}, type={part.get('type')}, material={part.get('material').get('name') if part.get('material') else None}"
+            )
+            if part:
+                parts.append(part)
+        except Exception as e:
+            print(f"Error fetching part with id {part_id}: {e}")
+
     return parts
 
 

--- a/python_magnetapi/utils.py
+++ b/python_magnetapi/utils.py
@@ -143,6 +143,26 @@ def get_object(
         return response
 
 
+def get_fk_id(obj: dict, field: str) -> int | None:
+    """
+    Extract the integer ID from a ForeignKey field in an object returned by get_object.
+
+    MagnetDB API returns ForeignKey fields as nested dicts, e.g.:
+        {"material": {"id": 5, "name": "copper", ...}}
+
+    This helper handles all three forms a FK field can appear in:
+    - dict with "id" key (API response): return dict["id"]
+    - int: return as-is (already an ID)
+    - None / missing: return None
+    """
+    value = obj.get(field)
+    if isinstance(value, dict):
+        return value.get("id")
+    if isinstance(value, int):
+        return value
+    return None
+
+
 def create_object(
     session,
     api_server: str,


### PR DESCRIPTION
MagnetDB API returns FK fields as nested objects, e.g.:
  {"material": {"id": 5, "name": "copper", ...}}

Add utils.get_fk_id(obj, field) to safely extract an FK id from any of the three forms it can appear in: nested dict, plain int, or None.

Update part.create() so that when the material field is already an API-response dict (contains "id"), the id is used directly instead of triggering an extra name lookup.

https://claude.ai/code/session_01CtcWGzTxG1pqfs5X97YAxy